### PR TITLE
Updated to handle new payloads, adds metric prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+.idea/


### PR DESCRIPTION
- Change to prepend `dd.` to all metric names
  - Potentially breaking changes, depends on how widely
    used this is.
- Updated to handle some new json structures in the
  payloads/messages, as of dd-agent version 5.20.2
- Switch to using `log.exception`, to reflect change in
  dd-agent itself